### PR TITLE
fix: supports ReadOnlySpace after V8-9.x

### DIFF
--- a/andb/dbg/dbg_lldb.py
+++ b/andb/dbg/dbg_lldb.py
@@ -157,7 +157,7 @@ class Value(intf.Value):
             v = self._I_value.GetChildMemberWithName(member_name_or_index)
         else:
             raise Exception
-
+        
         "lldb use Synthetic to format pretty print, here get the raw value"
         if v.IsSynthetic():
             #print("IsSynthetic", v)
@@ -215,7 +215,8 @@ class Value(intf.Value):
     def has(self, name):
         try:
             x = self[name]
-            return x is not None
+            #print ("has (%s) = %s, %s" % (name, x.size > 0, x))
+            return x.size > 0 
         except:
             return False
 

--- a/andb/shadow/heap_snapshot.py
+++ b/andb/shadow/heap_snapshot.py
@@ -460,8 +460,8 @@ class HeapSnapshot:
         """
         heap_obj = obj
         #heap_obj = v8.HeapObject(obj)
-        obj_type = heap_obj.instance_type
-        #print("AddEntryObject(0x%x), %s" % (heap_obj.address, v8.InstanceType.Name(obj_type)))
+        obj_type = heap_obj.map.instance_type
+        #print("AddEntryObject(0x%x), Map(0x%x), %s" % (heap_obj.address, heap_obj.map, v8.InstanceType.Name(obj_type)))
         #import traceback
         #traceback.print_stack()
 

--- a/andb/v8/enum.py
+++ b/andb/v8/enum.py
@@ -82,6 +82,19 @@ class AllocationSpace(Enum):
             cls.NEW_SPACE,
         ]
 
+    @classmethod
+    def NonROSpaces(cls):
+        return [
+            cls.MAP_SPACE,
+            cls.CODE_SPACE,
+            cls.CODE_LO_SPACE,
+            cls.OLD_SPACE,
+            cls.LO_SPACE,
+            cls.NEW_LO_SPACE,
+            cls.NEW_SPACE,
+        ]
+
+
 class AllocationType(Enum):
     _typeName = "v8::internal::AllocationType"
 

--- a/andb/v8/object.py
+++ b/andb/v8/object.py
@@ -1591,7 +1591,7 @@ class String(Name):
         elif t == Internal.kThinStringTag:
             v = self.Cast(ThinString)
         else:
-            raise IndexError(t, obj)
+            raise IndexError(t, "0x%x" % self)
         return v
 
     @staticmethod


### PR DESCRIPTION
Since V8-v9.x which has been used in node-v16 and node-v18 changed inheritance from v8::internal::PagedSpace to std::Vector based v8::internal::BaseSpace class, thus causes RO Space Iterator always return 0 object.

the patch implements an Iterator for the new introduced ReadOnlySpace.

```
(gdb) v8 version
9.4.146.26
9.4.146.26-node.22
(gdb) heap snap
Synchronize: (Strong roots)
Synchronize: (Bootstrapper)
Synchronize: (Relocatable)
Synchronize: (Debugger)
Synchronize: (Compilation cache)
Synchronize: (Builtins)
Synchronize: (Thread manager)
handles: 10000
handles: 13929
handles: 0
OnStackTracedNodeSpace.Iterate NotImplemented.
Synchronize: (Global handles)
Synchronize: (Stack roots)
Synchronize: (Handle scope)
Synchronize: (Eternal handles)
Synchronize: (Startup object cache)
Synchronize: (Internalized strings)
Synchronize: (External strings)
Iterated 1936 RO Heap Objects
...
```
