### PR TITLE
fix: show Oddball mid.

### DIFF
--- a/andb/v8/object.py
+++ b/andb/v8/object.py
@@ -472,6 +472,10 @@ class HeapObject(Object, Value):
         elif InstanceType.isScopeInfo(self.instance_type):
             o = ScopeInfo(self)
             mid = o.FunctionName()
+        
+        elif InstanceType.isOddball(self.instance_type):
+            o = Oddball(self)
+            mid = o.CamelName()
     
         tag = self.StrongTag()
 
@@ -950,6 +954,15 @@ class Oddball(HeapObject):
 
     def __str__(self):
         return str(self.to_string)
+
+    def CamelName(self):
+        s = str(self.to_string).lower().capitalize() 
+        if s.find('_') > 0:
+            y = []
+            for x in s.split('_'):
+                y.append(x.lower().capitalize())
+            return ''.join(y)
+        return s
 
     def IsFalse(self):
         return int(self.kind) == self.kFalse


### PR DESCRIPTION
Show Oddball Type in middle of Brief.

```
0x8b2d6d001b0: <Oddball Null 0x8b2d6d001b1>
0x8b2d6d00370: <Oddball Uninitialized 0x8b2d6d00371>
0x8b2d6d00470: <Oddball Undefined 0x8b2d6d00471>
0x8b2d6d00540: <Oddball Hole 0x8b2d6d00541>
0x8b2d6d005e0: <Oddball True 0x8b2d6d005e1>
0x8b2d6d00688: <Oddball False 0x8b2d6d00689>
0x8b2d6d00b38: <Oddball ArgumentsMarker 0x8b2d6d00b39>
0x8b2d6d00bd0: <Oddball Exception 0x8b2d6d00bd1>
0x8b2d6d00c68: <Oddball TerminationException 0x8b2d6d00c69>
0x8b2d6d00d08: <Oddball OptimizedOut 0x8b2d6d00d09>
0x8b2d6d00da0: <Oddball StaleRegister 0x8b2d6d00da1>
0x8b2d6d020d8: <Oddball SelfReferenceMarker 0x8b2d6d020d9>
```