### PR TITLE
fix: non-ascii in function name.

### DIFF
--- a/andb/v8/object.py
+++ b/andb/v8/object.py
@@ -3204,7 +3204,7 @@ class SharedFunctionInfo(HeapObject):
         name = self.GetFunctionName()
         if name is None or len(name) == 0:
             return ""
-        return str(name)
+        return name
 
     @CachedProperty
     def parameter_count(self):


### PR DESCRIPTION
Some JSFunctions may have non-ascii names, the patch fixed the issue,

```
Parse <0x3aa70fac0719> failed: 'ascii' codec can't encode character u'\uffe5' in position 0: ordinal not in range(128)
Parse <0x3aa70fac08c1> failed: 'ascii' codec can't encode character u'\uffe5' in position 0: ordinal not in range(128)
```

