### PR TITLE
Heapsnapshot exporting optimization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,31 @@ heap snapshot written to 'core.heapsnapshot'
 Generate() takes 14.012 second(s).
 (gdb)
 ``` 
+
 之后使用 devtools 打开 core.heapsnapshot 文件。
+
+
+使用 MapReduce 方法并行导出，
+
+当你有多核的服务器时，可使用 MapReduce 方式并行导出 core.heapsnapshot 文件，
+
+```bash
+$andb -g -c core.<pid> -m snapshot -j 16
+...
+Merging snapshot.d/snapshot_23.rec
+LoadFile() takes 7.145 second(s).
+Merge() takes 1.831 second(s).
+Polling done.
+Resolve all edges ...
+Done, resolved 4162, failed 0.
+Total Entry(7782138), Edge(31256137)
+heap snapshot written to 'core.heapsnapshot'
+ReduceGenerate() takes 766.309 second(s).
+real   811.173s
+map    22.984s
+parse  385.541s
+reduce 402.648s
+```
 
 #### v8 inspect \<tag\>
 

--- a/andb/__init__.py
+++ b/andb/__init__.py
@@ -36,4 +36,4 @@ def Load():
     t2 = time()
     print("andb loaded, cost %0.3f seconds." % (t2 - t1))
 
-print("andb.__init__ end")
+#print("andb.__init__ end")

--- a/andb/cli/cfg.py
+++ b/andb/cli/cfg.py
@@ -1,11 +1,13 @@
 # -*- coding: UTF-8 -*-
 from __future__ import print_function, division
 
+from andb.utility import to_bool
 from andb.dbg import Command, CommandPrefix
 from andb.config import Config
 
 class cli_andb(CommandPrefix):
     _cxpr = "andb"
+
 
 class cli_andb_config(Command):
     _cxpr = "andb config"
@@ -13,21 +15,42 @@ class cli_andb_config(Command):
     def invoke(self, argv):
         Config.Show()
 
+
 class cli_andb_set(Command):
     _cxpr = "andb set"
 
     def invoke(self, argv):
         Config.SetValue(argv[0], argv[1])
 
-class cli_andb_flag(Command):
-    _cxpr = "andb flag"
 
+class cli_andb_opt(CommandPrefix):
+    _cxpr = "andb option"
+
+
+class cli_andb_opt_chunk_cache(Command):
+    _cxpr = "andb option chunk_cache"
+
+    # default not enabled.
+    on_off = False
+    
+    @classmethod
+    def show_value(cls):
+        if cls.on_off: print("on")
+        else: print("off")
+
+    @classmethod
+    def set_value(cls, v):
+        import andb.v8 as v8
+        if v:
+            iso = v8.Isolate.GetCurrent()
+            iso.MakeChunkCache()
+        cls.on_off = v
+       
     def invoke(self, argv):
-        pass
-
-class cli_andb_flag_set(Command):
-    _cxpr = "andb flag set"
-
-    def invoke(self, argv):
-        pass
+        if len(argv) < 1:
+            self.show_value()
+            return
+        
+        v = to_bool(argv[0])
+        self.set_value(v)
 

--- a/andb/cli/cfg.py
+++ b/andb/cli/cfg.py
@@ -19,3 +19,15 @@ class cli_andb_set(Command):
     def invoke(self, argv):
         Config.SetValue(argv[0], argv[1])
 
+class cli_andb_flag(Command):
+    _cxpr = "andb flag"
+
+    def invoke(self, argv):
+        pass
+
+class cli_andb_flag_set(Command):
+    _cxpr = "andb flag set"
+
+    def invoke(self, argv):
+        pass
+

--- a/andb/cli/test.py
+++ b/andb/cli/test.py
@@ -53,6 +53,18 @@ class cli_test_find_function(Command):
     def invoke(self, argv):
         TestVisitor.FindFunction(argv)
 
+class cli_test_value(Command):
+    _cxpr = "test value"
+
+    def invoke(self, argv):
+        TestVisitor.ValueTest(argv)
+
+class cli_test_single(Command):
+    _cxpr = "test single"
+
+    def invoke(self, argv):
+        TestVisitor().SingleValue(argv)
+
 class cli_mm(CommandPrefix):
     _cxpr = "mm"
 

--- a/andb/cli/test.py
+++ b/andb/cli/test.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 
 from andb.dbg import Command, CommandPrefix, Target, Value, Type
 from andb.ptmalloc import ArenaVisitor
-from andb.shadow import ObjectVisitor, TestVisitor
+from andb.shadow import ObjectVisitor, TestVisitor, HeapSnapshot
 
 """ test commands
 """
@@ -156,4 +156,32 @@ class cli_objgraph_backrefs(Command):
         import objgraph
         obj = objgraph.at(argv[0])
         objgraph.show_backrefs(obj, max_depth=5, filename="og_b.png")
+
+
+class cli_mapreduce(CommandPrefix):
+    _cxpr = "mapreduce"
+
+
+class cli_mapreduce(Command):
+    _cxpr = "mapreduce map"
+
+    def invoke(self, argv):
+        snap = HeapSnapshot()
+        snap.WriteMap(int(argv[0]))
+
+class cli_snapshot(Command):
+    _cxpr = "mapreduce snapshot"
+
+    def invoke(self, argv):
+        snap = HeapSnapshot()
+        index = int(argv[0])
+        snap.DoReduce(index)
+
+class cli_mapreduce(Command):
+    _cxpr = "mapreduce reduce"
+
+    def invoke(self, argv):
+        snap = HeapSnapshot()
+        index = int(argv[0])
+        snap.ReduceGenerate(index)
 

--- a/andb/cli/test.py
+++ b/andb/cli/test.py
@@ -174,26 +174,25 @@ class cli_mapreduce(CommandPrefix):
     _cxpr = "mapreduce"
 
 
-class cli_mapreduce(Command):
-    _cxpr = "mapreduce map"
+class cli_mapreduce_index(Command):
+    _cxpr = "mapreduce index"
 
     def invoke(self, argv):
         snap = HeapSnapshot()
-        snap.WriteMap(int(argv[0]))
+        snap.MapWriteIndex(int(argv[0]))
 
-class cli_snapshot(Command):
+class cli_mapreduce_snapshot(Command):
     _cxpr = "mapreduce snapshot"
 
     def invoke(self, argv):
         snap = HeapSnapshot()
         index = int(argv[0])
-        snap.DoReduce(index)
+        snap.MapSnapshot(index)
 
-class cli_mapreduce(Command):
+class cli_mapreduce_reduce(Command):
     _cxpr = "mapreduce reduce"
 
     def invoke(self, argv):
         snap = HeapSnapshot()
-        index = int(argv[0])
-        snap.ReduceGenerate(index)
+        snap.ReduceGenerate()
 

--- a/andb/loader/__init__.py
+++ b/andb/loader/__init__.py
@@ -1,3 +1,3 @@
 from .elf import *
 from .core import *
-
+from .loader import * 

--- a/andb/loader/loader.py
+++ b/andb/loader/loader.py
@@ -62,21 +62,25 @@ class Loader(object):
     def AddArgs(self, args):
         if self._args is None:
             self._args = []
-        print(args)
+        #print(args)
         self._args.extend(args)
+
+    def AddCommandLine(self, l):
+        self.AddCommands([l.split()])
+
+    def AddCommandFile(self, f):
+        self.AddCommands([[FileWrap(f)]])
 
     def AddCommands(self, cmds):
         if self._commands is None:
             self._commands = []
         for a in cmds:
-            print (a)
+            #print(a)
             if isinstance(a[0], FileWrap):
                 cmd = a[0]
             else:
-                cmd = " ".join(a)
+                cmd = a
             self._commands.append(cmd)
-        for i in self._commands:
-            print(i)
 
     def default(self):
         raise NotImplementedError
@@ -96,8 +100,8 @@ class GdbLoader(Loader):
         return ['gdb', 
             '--nh',  # no ~/.gdbinit
             '--nx',  # no .gdbinit 
-            '-ix %s/init/gdbinit.cmd' % self._andb_dir,  # gdbinit commands
-            '-x %s/init/gdbinit.py' % self._andb_dir,    # gdbinit python script
+            '-ix', '%s/init/gdbinit.cmd' % self._andb_dir,  # gdbinit commands
+            '-x', '%s/init/gdbinit.py' % self._andb_dir,    # gdbinit python script
            ]
 
     def Opts(self):
@@ -106,13 +110,13 @@ class GdbLoader(Loader):
             opts.append(self._exec)
         
         if self._core:
-            opts.append('--core %s' % self._core)
+            opts.extend(['--core', '%s' % self._core])
         
         if self._typ:
             os.environ['ANDB_TYP'] = self._typ 
 
         if self._pid:
-            opts.append('--pid %d' % self._pid)
+            opts.extend(['--pid', '%d' % self._pid])
 
         if self._is_batch:
             opts.append('--batch')
@@ -120,9 +124,9 @@ class GdbLoader(Loader):
         if self._commands:
             for i in self._commands:
                 if isinstance(i, FileWrap):
-                    opts.append("-x '%s'" % i.FileName())
+                    opts.extend(["-x", '%s' % i.FileName()])
                 else:
-                    opts.append("-ex '%s'" % i)
+                    opts.extend(["-ex", " ".join(i)])
         
         if self._args:
             opts.extend(self._args)
@@ -139,8 +143,8 @@ class LldbLoader(Loader):
     def default(self):
         return ['lldb', 
             '-x',  # no any .lldbinit
-            '-o "com sc im %s/init/lldbinit.py"' % self._andb_dir,  # lldbinit python script
-            '-s %s/init/lldbinit.cmd' % self._andb_dir,             # lldbinit command
+            '-o', "com sc im %s/init/lldbinit.py" % self._andb_dir,  # lldbinit python script
+            '-s', "%s/init/lldbinit.cmd" % self._andb_dir,             # lldbinit command
            ]
 
     def Opts(self):
@@ -160,14 +164,13 @@ class LldbLoader(Loader):
         if self._commands:
             for i in self._commands:
                 if isinstance(i, FileWrap):
-                    opts.append("-s '%s'" % i.FileName())
+                    opts.extend(["-s", "%s" % i.FileName()])
                 else:
-                    opts.append("-o '%s'" % i)
+                    opts.extend(["-o", " ".join(i)])
  
         if self._args:
             opts.extend(self._args)
         
         print(opts)
         return opts
-
 

--- a/andb/loader/loader.py
+++ b/andb/loader/loader.py
@@ -1,9 +1,9 @@
-
 from __future__ import print_function
 import os
 
 class FileWrap(object):
-
+    """ warp object for file input.
+    """
     def __init__(self, f):
         self._file = f
     
@@ -11,6 +11,9 @@ class FileWrap(object):
         return str(self._file)
 
 class Loader(object):
+    """ Loader base for all debuggers 
+    """
+
     # binary to debug
     _exec = None
 
@@ -85,6 +88,8 @@ class Loader(object):
         return " ".join(slef.Opts())
 
 class GdbLoader(Loader):
+    """ GDB loader
+    """
 
     @property
     def default(self):
@@ -127,6 +132,8 @@ class GdbLoader(Loader):
 
 
 class LldbLoader(Loader):
+    """ GDB loader
+    """
 
     @property
     def default(self):
@@ -146,8 +153,21 @@ class LldbLoader(Loader):
             os.environ['ANDB_TYP'] = self._typ 
         if self._pid:
             opts.extend(['-p', self._pid])
+
+        if self._is_batch:
+            opts.append('-b')
+
+        if self._commands:
+            for i in self._commands:
+                if isinstance(i, FileWrap):
+                    opts.append("-s '%s'" % i.FileName())
+                else:
+                    opts.append("-o '%s'" % i)
+ 
         if self._args:
             opts.extend(self._args)
+        
+        print(opts)
         return opts
 
 

--- a/andb/shadow/heap_snapshot.py
+++ b/andb/shadow/heap_snapshot.py
@@ -1211,6 +1211,17 @@ class HeapSnapshot:
     def IterateHeapObjects(self):
         cnt = 0
         heap = self.heap()
+        spaces = v8.AllocationSpace.NonROSpaces()
+        for name in spaces:
+            space = heap.getSpace(name)
+            print(space)
+            chunks = space.getChunks()
+            for i in chunks:
+                print(i)
+
+    def IterateHeapObjects2(self):
+        cnt = 0
+        heap = self.heap()
         failed = []
         for obj in v8.HeapObjectIterator(heap):
             if cfg.cfgObjectDecodeFailedAction == 0:

--- a/andb/shadow/heap_snapshot.py
+++ b/andb/shadow/heap_snapshot.py
@@ -1944,6 +1944,7 @@ class HeapSnapshot(GraphHolder):
         while len(rec_files) > 0:
             print("reduce (%d/%d)" % (len_files - len(rec_files), len_files))
 
+            is_idle = 1
             for f in rec_files:
                 if os.path.exists(f):
                     print("Merging %s" % f)
@@ -1955,9 +1956,11 @@ class HeapSnapshot(GraphHolder):
                     parser.CleanAll()
                     
                     rec_files.remove(f)
+                    is_idle = 0
 
             # delay
-            time.sleep(5)
+            if is_idle:
+                time.sleep(5)
 
         print("Polling done.")
 

--- a/andb/shadow/heap_snapshot.py
+++ b/andb/shadow/heap_snapshot.py
@@ -1920,7 +1920,7 @@ class HeapSnapshot(GraphHolder):
         for p in pages:
             page = v8.MemoryChunk(p)
             cnt = cnt + 1
-            print("map_%d (%d/%d) page(0x%x)" % (index, cnt, len(pages), page))
+            print("map_%d (%d/%d) page(0x%x)" % (index, cnt, len(pages), int(page)))
             for obj in page.walk():
                 # skip free space
                 if v8.InstanceType.isFreeSpace(obj.instance_type) and \

--- a/andb/shadow/visitor.py
+++ b/andb/shadow/visitor.py
@@ -22,7 +22,7 @@ class IsolateGuesser:
         v8.Isolate.SetCurrent(iso)
         # set convenience_variable
         dbg.ConvenienceVariables.Set('isolate', pyo_iso._I_value)
-        iso.MakeChunkCache()
+        #iso.MakeChunkCache()
 
     def CheckIsolate(self, address):
         try:

--- a/andb/shadow/visitor.py
+++ b/andb/shadow/visitor.py
@@ -18,9 +18,11 @@ class IsolateGuesser:
     """
    
     def SetIsolate(self, pyo_iso):
-        v8.Isolate.SetCurrent(v8.Isolate(pyo_iso))
+        iso = v8.Isolate(pyo_iso)
+        v8.Isolate.SetCurrent(iso)
         # set convenience_variable
         dbg.ConvenienceVariables.Set('isolate', pyo_iso._I_value)
+        iso.MakeChunkCache()
 
     def CheckIsolate(self, address):
         try:
@@ -651,5 +653,80 @@ class TestVisitor(object):
         heap = iso.Heap()
         space = heap.getSpace('old')
         
+    @classmethod
+    def ValueTest(cls, argv):
+        from time import time
+        import struct
+        #iso = v8.Isolate.GetCurrent()
+        #heap = iso.Heap()
+        tag = int(argv[0], 16)
+        ptr = tag & ~v8.Internal.kHeapObjectTagMask 
 
+        buf = dbg.Target.MemoryRead(ptr, 80)
+
+        t = time()
+        for i in range(1000000):
+            o = ptr 
+        print("for %.3f" % (time()-t))
+
+        t = time()
+        for i in range(1000000):
+            o = object() 
+        print("object() %.3f" % (time()-t))
+
+        t = time()
+        for i in range(1000000):
+            o = v8.HeapObject(tag)
+        print("HeapObject() %.3f" % (time()-t))
+
+        t = time()
+        for i in range(1000000):
+            r = v8.ChunkBlock() 
+            r.InitReader(ptr)
+        print("ChunkBlock() %.3f" % (time()-t))
+
+        t = time()
+        for i in range(1000000):
+            r = v8.ChunkBlock() 
+            r.InitReader(ptr)
+            o = r.LoadU64(0)
+        print("ChunkBlock().LoadU64 %.3f" % (time()-t))
+
+        t = time()
+        for i in range(1000000):
+            o = v8.HeapObject(tag)
+            m = o.instance_type
+        print("HeapObject.instance_type %.3f" % (time()-t))
+
+        t = time()
+        for i in range(1000000):
+            o = dbg.Block()
+            o._address = ptr
+        print("dbg.Block %.3f" % (time()-t))
+
+        t = time()
+        for i in range(1000000):
+            o = dbg.Block()
+            o._address = ptr
+            m = o.LoadU64(0)
+        print("dbg.Block.LoadU64 %.3f" % (time()-t))
+
+        t = time()
+        for i in range(1000000):
+            m = struct.unpack_from("Q", buf, 0)
+        print("struct.unpack %.3f" % (time()-t))
+
+    @profiler
+    def SingleValue(self, argv):
+        from time import time
+        #iso = v8.Isolate.GetCurrent()
+        #heap = iso.Heap()
+        tag = int(argv[0], 16)
+        ptr = tag & ~v8.Internal.kHeapObjectTagMask 
+
+        count = 1000000
+        t = time()
+        for i in range(count):
+            o = v8.HeapObject(tag)
+        print("HeapObject() %.3f" % (time()-t))
 

--- a/andb/utility.py
+++ b/andb/utility.py
@@ -187,3 +187,10 @@ def DCHECK(statement, *args):
     """
     assert statement, args 
 
+def to_bool(value):
+    """ convert string to bool
+    """
+    if str(value).lower() in ("yes", "on", "y", "true", "1"): return True
+    if str(value).lower() in ("no",  "off", "n", "false", "0", "0.0", "", "none"): return False
+    raise Exception('Invalid value for boolean conversion: ' + str(value)) 
+

--- a/andb/v8/__init__.py
+++ b/andb/v8/__init__.py
@@ -35,7 +35,7 @@ from __future__ import print_function, division
 
 from .internal import *
 from .enum import *
-from .struct import *
+from .structure import *
 from .object import *
 from .iterator import *
 from .frame import *

--- a/andb/v8/enum.py
+++ b/andb/v8/enum.py
@@ -94,6 +94,16 @@ class AllocationSpace(Enum):
             cls.NEW_SPACE,
         ]
 
+    @classmethod
+    def OnlyOldSpaces(cls):
+        return [
+            cls.MAP_SPACE,
+            cls.CODE_SPACE,
+            cls.CODE_LO_SPACE,
+            cls.OLD_SPACE,
+            cls.LO_SPACE,
+        ]
+
 
 class AllocationType(Enum):
     _typeName = "v8::internal::AllocationType"

--- a/andb/v8/frame.py
+++ b/andb/v8/frame.py
@@ -248,6 +248,7 @@ class StandardFrame(StackFrame, StandardFrameConstants):
 
     def __init__(self, frame):
         StackFrame.__init__(self, frame)
+        StandardFrameConstants.__init__(self, frame)
         self._context = frame._context_or_frame_type
 
     def Parse(self, context):
@@ -274,6 +275,7 @@ class TypedFrame(StackFrame, TypedFrameConstants):
 
     def __init__(self, frame):
         StackFrame.__init__(self, frame)
+        TypedFrameConstants.__init__(self, frame)
         #self._frame_type = StackFrameType(frame._context_or_frame_type)
 
     def Parse(self, frame_type):

--- a/andb/v8/frame.py
+++ b/andb/v8/frame.py
@@ -75,7 +75,6 @@ class CommonFrameConstants(Value):
             {"name": "context_or_frame_type", "type": Object, "offset": cls.kContextOrFrameTypeOffset},
         ]}
 
-
 class StandardFrameConstants(CommonFrameConstants):
     _typeName = 'v8::internal::StandardFrameConstants'
 
@@ -196,6 +195,7 @@ class StackFrame(dbg.Frame):
         if isinstance(frame, dbg.Frame):
             dbg.Frame.__init__(self, frame)
             self._address = frame.GetFP()
+            addr = frame.GetFP()
         elif isinstance(frame, StackFrame):
             self._I_frame = frame._I_frame
             self._address = frame._address
@@ -248,7 +248,8 @@ class StandardFrame(StackFrame, StandardFrameConstants):
 
     def __init__(self, frame):
         StackFrame.__init__(self, frame)
-        StandardFrameConstants.__init__(self, frame)
+        self.InitReader(self._address)
+        #StandardFrameConstants.__init__(self, frame)
         self._context = frame._context_or_frame_type
 
     def Parse(self, context):
@@ -275,7 +276,8 @@ class TypedFrame(StackFrame, TypedFrameConstants):
 
     def __init__(self, frame):
         StackFrame.__init__(self, frame)
-        TypedFrameConstants.__init__(self, frame)
+        self.InitReader(self._address)
+        #TypedFrameConstants.__init__(self, frame)
         #self._frame_type = StackFrameType(frame._context_or_frame_type)
 
     def Parse(self, frame_type):

--- a/andb/v8/frame.py
+++ b/andb/v8/frame.py
@@ -261,11 +261,13 @@ class StandardFrame(StackFrame, StandardFrameConstants):
 
     def GetParameter(self, index):
         off = self.GetParameterOffset(index)
-        return Object(self.LoadPtr(off))
+        v = Object(self.LoadPtr(off))
+        return v
 
     def GetParameterOffset(self, index):
         fn = self._function
         param_count = fn.shared_function_info.parameter_count
+        #print("param_count(%d)" % param_count, "%x" % fn)
         assert -1 <= index < param_count
         offset = (param_count - index - 1) * Internal.kSystemPointerSize
         return self.caller_sp__offset + offset

--- a/andb/v8/iterator.py
+++ b/andb/v8/iterator.py
@@ -738,7 +738,7 @@ from .enum import (
     PropertyKind,
     PropertyLocation,
 )
-from .struct import (
+from .structure import (
     PagedSpace, 
     MemoryChunk,
     RootsTable,

--- a/andb/v8/object.py
+++ b/andb/v8/object.py
@@ -363,7 +363,7 @@ class HeapObject(Object, Value):
 
     @property
     def ptr(self):
-        return self._address
+        return self.address
 
     @classmethod
     def cType(cls, val):

--- a/andb/v8/object.py
+++ b/andb/v8/object.py
@@ -2,7 +2,7 @@
 from __future__ import print_function, division
 
 import re
-import struct
+#import struct
 
 from functools import wraps
 from andb.utility import Logging as log, oneshot, CachedProperty
@@ -310,7 +310,9 @@ class HeapObject(Object, Value):
 
     def __init__(self, obj):
         tag = int(obj)
-        self._address = tag & (~Internal.kHeapObjectTagMask)
+        #self._address = tag & (~Internal.kHeapObjectTagMask)
+        address = tag & (~Internal.kHeapObjectTagMask)
+        self.InitReader(address)
 
     def __int__(self):
         return self.tag
@@ -380,6 +382,7 @@ class HeapObject(Object, Value):
     @CachedProperty
     def instance_type(self):
         """ return Instance Type (InstanceType) """
+        return self.map.instance_type
         try:
             return self.map.instance_type
         except Exception as e:
@@ -708,6 +711,9 @@ class Map(HeapObject):
 
     _typeName = 'v8::internal::Map'
 
+    # cache all Map Object 
+    _map_cache = {} 
+
     """
     // All heap objects have a Map that describes their structure.
     //  A Map contains information about:
@@ -864,6 +870,11 @@ class Map(HeapObject):
             {'name': 'prototype_validity_cell', 'type': Object},  # [Smi, Cell]
             {'name': 'transitions_or_prototype_info', 'type': Object},  # [Map, TransitionArray, PrototypeInfo, Smi]},
         ]}
+
+    #def __new__(cls, tag):
+    #    ret = super(Map, cls).__new__(cls, tag)
+    #    print(ret)
+    #    return ret
 
     """ bitfield helper
     """
@@ -2858,16 +2869,16 @@ class JSObject(JSReceiver):
            
         receiver = self
         # Lookup Symbol.toStringTag
-        it_symbol_to_string_tag = LookupIterator(receiver, 
-                name="Symbol.toStringTag",
-                configuration=LookupIterator.Configuration.PROTOTYPE_CHAIN_SKIP_INTERCEPTOR,
-            )
-        maybe_tag = it_symbol_to_string_tag.GetDataProperty()
-        if maybe_tag:
-            tag = String(maybe_tag)
-            if tag.IsString():
-                #print("2 GetConstructorTuple.tag_name")
-                return (None, tag.ToString())
+        #it_symbol_to_string_tag = LookupIterator(receiver, 
+        #        name="Symbol.toStringTag",
+        #        configuration=LookupIterator.Configuration.PROTOTYPE_CHAIN_SKIP_INTERCEPTOR,
+        #    )
+        #maybe_tag = it_symbol_to_string_tag.GetDataProperty()
+        #if maybe_tag:
+        #    tag = String(maybe_tag)
+        #    if tag.IsString():
+        #        #print("2 GetConstructorTuple.tag_name")
+        #        return (None, tag.ToString())
 
         # Protoperty Iterator
         it = PrototypeIterator(receiver) 
@@ -3966,7 +3977,7 @@ from .enum import (
     RepresentationKind,
 )
 
-from .struct import (
+from .structure import (
     Isolate,
 )
 

--- a/andb/v8/object.py
+++ b/andb/v8/object.py
@@ -379,11 +379,11 @@ class HeapObject(Object, Value):
             m = m.GetMap2(allow_forward=0)
         return m
 
-    @property
+    @CachedProperty
     def map(self):
         m = self.map_or_trans
         if m.IsSmi():
-            m = self.map_or_trans.map
+            m = m.map_or_trans
         return m
 
     @CachedProperty
@@ -3229,8 +3229,14 @@ class SharedFunctionInfo(HeapObject):
 
     @CachedProperty
     def parameter_count(self):
-        return self.formal_parameter_count
-
+        """ Corrected parameter_count
+        """
+        cnt = self.formal_parameter_count
+        # uint16_max kDontAdaptArgumentsSentinel
+        if cnt == 65535:
+            cnt = 0
+        return cnt
+    
     def DebugPrint2(self):
         print(" - function_data :", Object.SBrief(self.function_data))
         print(" - name:", Object.SBrief(self.name_or_scope_info))

--- a/andb/v8/object_v8.py
+++ b/andb/v8/object_v8.py
@@ -312,7 +312,7 @@ from .enum import (
     IsStaicFlag,
 )
 
-from .struct import (
+from .structure import (
     Isolate,
 )
 

--- a/andb/v8/object_v8.py
+++ b/andb/v8/object_v8.py
@@ -203,7 +203,13 @@ class ScopeInfo(FixedArray):
         """ index to offset
         """
         return self.kFlagsOffset + (index * Internal.kTaggedSize)
-    
+ 
+    @property
+    def is_empty(self):
+        if self.length == 0:
+            return True
+        return False
+   
     @property
     def has_saved_class_variable_index(self):
         return self.flags.has_saved_class_variable_index

--- a/andb/v8/object_v9.py
+++ b/andb/v8/object_v9.py
@@ -146,6 +146,10 @@ class ScopeInfo(HeapObject):
         ]}
 
     @property
+    def is_empty(self):
+        return False 
+
+    @property
     def has_saved_class_variable_index(self):
         return self.flags.has_saved_class_variable_index
 

--- a/andb/v8/object_v9.py
+++ b/andb/v8/object_v9.py
@@ -402,7 +402,7 @@ from .enum import (
     IsStaicFlag,
 )
 
-from .struct import (
+from .structure import (
     Isolate,
 )
 

--- a/andb/v8/struct.py
+++ b/andb/v8/struct.py
@@ -775,6 +775,12 @@ class Space(Struct):
             yield chunk
             ptr = ptr['list_node_']['next_']
 
+    def getChunks(self):
+        chunks = []
+        for i in self.walkPages():
+            chunks.append(i)
+        return chunks
+
 
 class SpaceWithLinearArea(Space):
     _typeName = 'v8::internal::SpaceWithLinearArea'
@@ -852,12 +858,25 @@ class NewSpace(SpaceWithLinearArea):
         from_committed = self.from_space.committed
         return to_committed + from_committed 
 
+    #def walkPages(self):
+    #    for i in self.from_space.walkPages():
+    #        yield i
+    #    for i in self.to_space.walkPages():
+    #        yield i
+
+    def getChunks(self):
+        chunks = []
+        for i in self.walkPages():
+            chunks.append(i)
+        return chunks
+
     def show_sl(self):
         to_committed = self.to_space.committed
         from_committed = self.from_space.committed
         print("%-14s: %10u" % (self.name, to_committed + from_committed))
         print(" - from_space : %10u" % from_committed)
         print(" - to_space   : %10u" % to_committed)
+
 
 if Version.major >= 9:
     class ReadOnlySpace(Struct):

--- a/andb/v8/struct.py
+++ b/andb/v8/struct.py
@@ -620,9 +620,18 @@ class MemoryChunk(Struct):
             if ptr == spc.top and ptr != spc.limit:
                 ptr = spc.limit
                 continue
-            ho = HeapObject(ptr)
+
+            ho = HeapObject.FromAddress(ptr)
+            if not ho.Access():
+                return
+
             # mp = ho.GetMap()
-            size = ho.Size()
+            try:
+                size = ho.Size()
+            except:
+                print("failed: %x"  % ptr)
+                return
+
             # print("Object(0x%x) size(%d) %s" % (ptr, size, InstanceType.Name(mp.GetType())))
             yield ho
             ptr += size

--- a/andb/v8/structure.py
+++ b/andb/v8/structure.py
@@ -831,6 +831,7 @@ class PagedSpace(SpaceWithLinearArea):
     def show_sl(self):
         print("%-14s: %10u %10u" % (self.name, self.committed, self.max_committed))
 
+
 class SemiSpace(SpaceWithLinearArea):
     _typeName = 'v8::internal::SemiSpace'
 
@@ -922,6 +923,16 @@ if Version.major >= 9:
 
         def show_sl(self):
             print("%-14s: %10u %10u" % (self.name, self.committed, self.max_committed))
+
+        def walkPages(self):
+            for i in stl.Vector(self['pages_']).__iter__():
+                yield MemoryChunk(i)
+
+        def getChunks(self):
+            chunks = []
+            for i in self.walkPages():
+                chunks.append(i)
+            return chunks
 
 else:
     class ReadOnlySpace(PagedSpace):

--- a/andb/v8/structure.py
+++ b/andb/v8/structure.py
@@ -111,7 +111,10 @@ class Isolate(Struct):
             space = heap.getSpace(name)
             chunks = space.getChunks()
             for i in chunks:
-                ChunkBlock.AddChunk(i)
+                try:
+                    ChunkBlock.AddChunk(i)
+                except Exception as e:
+                    print('AddChunk %x failed, %s' % (i, e))
         print("Done ChunkCache, %d chunks cached." % ChunkBlock.CacheSize())
 
     def Heap(self):

--- a/init/pre_mapreduce.cmd
+++ b/init/pre_mapreduce.cmd
@@ -1,0 +1,3 @@
+iso g p 
+andb option chunk_cache on
+

--- a/loader
+++ b/loader
@@ -72,26 +72,18 @@ args, dbg_opts = parser.parse_known_args()
 #print('gdb:', args.gdb, 'lldb:', args.lldb,
 #  'core:', args.core, 'binary:', args.binary, 'opts:', args.opts)
 
-
-# leader the new process group
-os.setpgrp()
+# node and node.typ path
+binary = None
+typfile = None
 
 def Abort():
     print("Aborted, killall sub-processes.")
     os.killpg(0, 9)
 
-# register signal
 def term_handler(signo, frame):
     print('')
     print("Received Signal(%d)" % signo)
     Abort()
-
-signal.signal(signal.SIGINT, term_handler)
-signal.signal(signal.SIGTERM, term_handler)
-
-# node and node.typ path
-binary = None
-typfile = None
 
 def GetLoader(andb_dir):
     if args.gdb:
@@ -133,7 +125,7 @@ def IndexProcess(size):
     loader.AddCommandFile('%s/init/pre_mapreduce.cmd'%andb_dir)
     loader.AddCommandLine('mapreduce index %d'%size)
     opts = loader.Opts()
-    os.spawnvp(os.P_WAIT, opts[0], opts)
+    return os.spawnvp(os.P_WAIT, opts[0], opts)
 
 def SnapProcess(index):
     print("my index is %d" % index)
@@ -145,6 +137,7 @@ def SnapProcess(index):
     loader.AddCommandFile('%s/init/pre_mapreduce.cmd'%andb_dir)
     loader.AddCommandLine('mapreduce snapshot %d'%index)
     opts = loader.Opts()
+    #os.execp(opts[0], opts)
     os.spawnvp(os.P_WAIT, opts[0], opts)
 
 def ReduceProcess(concurrency):
@@ -212,15 +205,22 @@ def MapReduce():
     print('parse  {:.3f}s'.format(t2-t1))
     print('reduce {:.3f}s'.format(t3-t2))
 
-# map reduce mode
-if args.mode:
-    MapReduce()
-    exit(0)
+if __name__ == '__main__':
+    # leader the new process group
+    os.setpgrp()
+    signal.signal(signal.SIGINT, term_handler)
+    signal.signal(signal.SIGTERM, term_handler)
 
-# single process mode
-else:
+    # map reduce mode
+    if args.mode:
+        MapReduce()
+        exit(0)
+
     loader = GetLoader(andb_dir)
+    if loader is None:
+        exit(0)
 
+    # single process mode
     if binary: 
         loader.SetExec(binary)
     if args.core:

--- a/loader
+++ b/loader
@@ -107,9 +107,9 @@ elif args.core:
     if 'bin' in info:
         binary = info['bin']
 
-def MapProcess(concurrency):
+def IndexProcess(size):
     loader = GetLoader(andb_dir)
-    cmds = ['iso g p', 'mapreduce map %d'%concurrency]
+    cmds = ['iso g p', 'mapreduce index %d'%size]
     cmds = [x.split() for x in cmds]
     loader.SetExec(binary)
     loader.SetTyp(typfile)
@@ -123,7 +123,7 @@ def MapProcess(concurrency):
 def SnapProcess(index):
     print("my index is %d" % index)
     loader = GetLoader(andb_dir)
-    cmds = ['iso g p', 'mapreduce snapshot %d'%index]
+    cmds = ['iso g p', 'mapreduce snapshot %d' % index]
     cmds = [x.split() for x in cmds]
     loader.SetExec(binary)
     loader.SetTyp(typfile)
@@ -136,7 +136,7 @@ def SnapProcess(index):
 
 def ReduceProcess(concurrency):
     loader = GetLoader(andb_dir)
-    cmds = ['iso g p', 'mapreduce reduce %d'%concurrency]
+    cmds = ['iso g p', 'mapreduce reduce']
     cmds = [x.split() for x in cmds]
     loader.SetExec(binary)
     loader.SetTyp(typfile)
@@ -148,8 +148,9 @@ def ReduceProcess(concurrency):
     return opts
 
 def MapReduce():
-    from multiprocessing import Process
+    from multiprocessing import Process, Pool
     from time import time
+    import re
 
     t0 = time()
     concurrency = 4 
@@ -157,33 +158,47 @@ def MapReduce():
         concurrency = args.jobs
 
     # map 
-    p = Process(target=MapProcess, args=(concurrency,))
+    p = Process(target=IndexProcess, args=(100,))
     p.start()
     p.join()
     t1 = time()
 
     # reduce
-    plist=[]
-    for i in range(concurrency):
-        p = Process(target=SnapProcess, args=(i,))
-        p.start()
-        plist.append(p)
+    #plist=[]
+    #for i in range(concurrency):
+    #    p = Process(target=SnapProcess, args=(i,))
+    #    p.start()
+    #    plist.append(p)
 
-    for p in plist:
-        print(p)
-        p.join()
+    #for p in plist:
+    #    print(p)
+    #    p.join()
+
+    reduce_process = Process(target=ReduceProcess, args=(concurrency,))
+    # final 
+    reduce_process.start()
+    
+    maps = [] 
+    for f in os.listdir("snapshot.d"):
+        if f.endswith(".map"):
+            n = re.findall(r'\d+', f)[0]
+            maps.append(int(n))
+    maps.sort()
+    print(maps)
+
+    pool = Pool(processes=concurrency) 
+    [ pool.apply_async(SnapProcess, (i,)) for i in maps ]
+    pool.close()
+    pool.join()
     t2 = time()
 
-    # final 
-    p = Process(target=ReduceProcess, args=(concurrency,))
-    p.start()
-    p.join()
+    reduce_process.join()
     t3 = time()
 
     print('real   {:.3f}s'.format(t3-t0))
     print('map    {:.3f}s'.format(t1-t0))
-    print('reduce {:.3f}s'.format(t2-t1))
-    print('final  {:.3f}s'.format(t3-t2))
+    print('parse  {:.3f}s'.format(t2-t1))
+    print('reduce {:.3f}s'.format(t3-t2))
 
 # map reduce mode
 if args.mode:

--- a/loader
+++ b/loader
@@ -164,18 +164,7 @@ def MapReduce():
     t1 = time()
 
     # reduce
-    #plist=[]
-    #for i in range(concurrency):
-    #    p = Process(target=SnapProcess, args=(i,))
-    #    p.start()
-    #    plist.append(p)
-
-    #for p in plist:
-    #    print(p)
-    #    p.join()
-
     reduce_process = Process(target=ReduceProcess, args=(concurrency,))
-    # final 
     reduce_process.start()
     
     maps = [] 
@@ -186,6 +175,7 @@ def MapReduce():
     maps.sort()
     print(maps)
 
+    # parse
     pool = Pool(processes=concurrency) 
     [ pool.apply_async(SnapProcess, (i,)) for i in maps ]
     pool.close()

--- a/loader
+++ b/loader
@@ -31,9 +31,9 @@ A better experience for any node.js developers.
     andb -l -c core
     andb -g -c core
     
-    -l, --lldb : choose lldb for debugging
+    -l, --lldb : choose lldb for debugging (default)
     -g, --gdb  : choose gdb for debgging
-    -c, --core : corefile path 
+    -c, --core : path to corefile 
 
 2) Debug a live process, 
     
@@ -99,9 +99,7 @@ def term_handler(signo, frame):
 def GetLoader(andb_dir):
     if args.gdb:
         return GdbLoader(andb_dir)
-    elif args.lldb:
-        return LldbLoader(andb_dir)
-    return None
+    return LldbLoader(andb_dir)
 
 if args.binary:
     """ use specified binary

--- a/loader
+++ b/loader
@@ -22,31 +22,42 @@ from andb.loader import FileWrap, GdbLoader, LldbLoader
 import argparse
 
 loader_desc = """
-Alinode Debugger Loader
+Alibaba Noslate Debugger Loader
 
 A better experience for any node.js developers.
 
-1) auto download binary (but not start a debugger session)
-   andb can auto download the matched binary and typ file from remote. 
-     
-    andb -c core
-
-2) debug only a corefile using lldb
-   (imply auto download binary, if found)
+1) Debugging a corefile using lldb/gdb, 
+    
     andb -l -c core
+    andb -g -c core
+    
+    -l, --lldb : choose lldb for debugging
+    -g, --gdb  : choose gdb for debgging
+    -c, --core : corefile path 
 
-3) debug a corefile with local binary
-    andb -l node -c core
-
-4) start a new process
-    andb -l node
-
-5) debug a live process
+2) Debug a live process, 
+    
     andb -l -p <pid>
+    
+    -p, --pid : pid of living process
 
-choose your favourite debugger:
-  andb -g or --gdb     : request a gdb console.
-  andb -l or --lldb    : request a lldb console.
+3) Batch debugging,
+
+    andb -l -c core -b -xf export_snapshot.cmd
+    andb -l -c core -b -x iso g p
+    
+    -b, --batch : batch mode
+    -xf, --command-file : command from file
+    -x, --command : command from line
+
+    -x and -xf can be used multiple times and in conjunction. 
+
+4) Export core.heapsnapshot by MapReduce,
+
+    andb -l -c core -m snapshot -j 4
+
+    -m  : --mode, MapReduce mode.
+    -j  : --jobs, allow N jobs at once.
 
 """
 
@@ -216,11 +227,13 @@ if __name__ == '__main__':
         MapReduce()
         exit(0)
 
-    loader = GetLoader(andb_dir)
-    if loader is None:
+    if binary is None and \
+        args.core is None and \
+        args.pid is None:
         exit(0)
 
     # single process mode
+    loader = GetLoader(andb_dir)
     if binary: 
         loader.SetExec(binary)
     if args.core:

--- a/loader
+++ b/loader
@@ -10,6 +10,14 @@ del _
 
 import os
 import sys
+
+print(os.path.abspath(__file__))
+dirname, filename = os.path.split(__file__)
+dirname = os.path.expanduser(dirname)
+andb_dir = os.path.abspath(dirname)
+
+from andb.loader import FileWrap, GdbLoader, LldbLoader
+
 import argparse
 
 loader_desc = """
@@ -45,16 +53,17 @@ parser = argparse.ArgumentParser(description=loader_desc, formatter_class=argpar
 parser.add_argument('-g', '--gdb', action='store_true', help='using gdb as debugger.')
 parser.add_argument('-l', '--lldb', action='store_true', help='using lldb as debugger. (default)')
 parser.add_argument('-p', '--pid', nargs=1, type=int, help='the process id to attach to.')
-parser.add_argument('-c', '--core', nargs="?", type=str, help='path to corefile')
+parser.add_argument('-b', '--batch', action='store_true', help='the process id to attach to.')
+parser.add_argument('-t', '--tag', nargs=1, type=int, help='specified version for debugging.')
+parser.add_argument('-m', '--mode', nargs=1, choices=['snapshot', 'cache'], help='mapreduce mode (snapshot, cache).') 
+parser.add_argument('-j', '--jobs', action='store', type=int, help='jobs for mapreduce.')
+parser.add_argument('-x', '--command', dest='cmds', action='append', nargs="+", type=str, help='eval command can be multiple times.')
+parser.add_argument('-xf', '--command-file', dest='cmds', action='append', nargs=1, type=FileWrap, help='eval command can be multiple times.')
+parser.add_argument('-c', '--core', nargs="?", type=str, help='path to corefile.')
 parser.add_argument('--args', nargs=argparse.REMAINDER, help='debugger options')
 parser.add_argument('binary', nargs="?", type=str, help='node or shinki binaray')
 
 args, dbg_opts = parser.parse_known_args()
-
-print(os.path.abspath(__file__))
-dirname, filename = os.path.split(__file__)
-dirname = os.path.expanduser(dirname)
-andb_dir = os.path.abspath(dirname)
 
 #if not andb_dir in sys.path:
 #    sys.path.insert(0, andb_dir)
@@ -62,7 +71,17 @@ andb_dir = os.path.abspath(dirname)
 #print('gdb:', args.gdb, 'lldb:', args.lldb,
 #  'core:', args.core, 'binary:', args.binary, 'opts:', args.opts)
 
+print(args)
+
+def GetLoader(andb_dir):
+    if args.gdb:
+        return GdbLoader(andb_dir)
+    elif args.lldb:
+        return LldbLoader(andb_dir)
+    return None
+
 binary = None
+typfile = None
 
 if args.binary:
     """ use specified binary
@@ -82,53 +101,112 @@ elif args.core:
     corefileAuxiliaryDownloader = CorefileAuxiliaryDownloader()
     info = corefileAuxiliaryDownloader.Download(buildId)
 
-    os.environ['ANDB_TYP'] = info['typ']
+    typfile = info['typ']
+    os.environ['ANDB_TYP'] = typfile 
 
     if 'bin' in info:
         binary = info['bin']
 
+def MapProcess(concurrency):
+    loader = GetLoader(andb_dir)
+    cmds = ['iso g p', 'mapreduce map %d'%concurrency]
+    cmds = [x.split() for x in cmds]
+    loader.SetExec(binary)
+    loader.SetTyp(typfile)
+    loader.SetCore(args.core)
+    loader.BatchOn()
+    loader.AddCommands(cmds)
+    opts = loader.Opts()
+    os.system(" ".join(opts)) 
+    return opts
 
-if args.lldb:
-    """ start lldb
-    """
-    opts = ['lldb', 
-            '-x',  # no any .lldbinit
-            '-o "com sc im %s/init/lldbinit.py"' % andb_dir,  # lldbinit python script
-            '-s %s/init/lldbinit.cmd' % andb_dir,  # lldbinit command
-           ]
-    if binary:
-        opts.append(binary)
+def SnapProcess(index):
+    print("my index is %d" % index)
+    loader = GetLoader(andb_dir)
+    cmds = ['iso g p', 'mapreduce snapshot %d'%index]
+    cmds = [x.split() for x in cmds]
+    loader.SetExec(binary)
+    loader.SetTyp(typfile)
+    loader.SetCore(args.core)
+    loader.BatchOn()
+    loader.AddCommands(cmds)
+    opts = loader.Opts()
+    os.system(" ".join(opts)) 
+    return opts
+
+def ReduceProcess(concurrency):
+    loader = GetLoader(andb_dir)
+    cmds = ['iso g p', 'mapreduce reduce %d'%concurrency]
+    cmds = [x.split() for x in cmds]
+    loader.SetExec(binary)
+    loader.SetTyp(typfile)
+    loader.SetCore(args.core)
+    loader.BatchOn()
+    loader.AddCommands(cmds)
+    opts = loader.Opts()
+    os.system(" ".join(opts)) 
+    return opts
+
+def MapReduce():
+    from multiprocessing import Process
+    from time import time
+
+    t0 = time()
+    concurrency = 4 
+    if args.jobs:
+        concurrency = args.jobs
+
+    # map 
+    p = Process(target=MapProcess, args=(concurrency,))
+    p.start()
+    p.join()
+    t1 = time()
+
+    # reduce
+    plist=[]
+    for i in range(concurrency):
+        p = Process(target=SnapProcess, args=(i,))
+        p.start()
+        plist.append(p)
+
+    for p in plist:
+        print(p)
+        p.join()
+    t2 = time()
+
+    # final 
+    p = Process(target=ReduceProcess, args=(concurrency,))
+    p.start()
+    p.join()
+    t3 = time()
+
+    print('real   {:.3f}s'.format(t3-t0))
+    print('map    {:.3f}s'.format(t1-t0))
+    print('reduce {:.3f}s'.format(t2-t1))
+    print('final  {:.3f}s'.format(t3-t2))
+
+# map reduce mode
+if args.mode:
+    MapReduce()
+    exit(0)
+
+# single process mode
+else:
+    loader = GetLoader(andb_dir)
+
+    if binary: 
+        loader.SetExec(binary)
     if args.core:
-        opts.extend(["-c", args.core])
+        loader.SetCore(args.core)
     if args.pid:
-        opts.append("-p %d" % args.pid[0])
-    if dbg_opts:
-        opts.extend(dbg_opts)
+        loader.SetPid("-p %d" % args.pid[0])
+    if args.batch:
+        loader.BatchOn()
     if args.args and len(args.args) > 0:
-        opts.extend(args.args)
+        loader.AddArgs(args.args)
+    if args.cmds and len(args.cmds) > 0:
+        loader.AddCommands(args.cmds)
 
-    print(" ".join(opts))
+    opts = loader.Opts() 
     os.system(" ".join(opts))
 
-elif args.gdb:
-    """ start gdb 
-    """
-    opts = ['gdb', 
-            '--nh',  # no ~/.gdbinit
-            '--nx',  # no .gdbinit 
-            '-ix %s/init/gdbinit.cmd' % andb_dir,  # gdbinit commands
-            '-x %s/init/gdbinit.py' % andb_dir,  # gdbinit python script
-           ]
-    if binary:
-        opts.append(binary)
-    if args.core:
-        opts.append(args.core)
-    if args.pid:
-        opts.append("-p %d" % args.pid[0])
-    if dbg_opts:
-        opts.extend(dbg_opts)
-    if args.args and len(args.args) > 0:
-        opts.extend(args.args)
-
-    print(" ".join(opts))
-    os.system(" ".join(opts)) 

--- a/loader
+++ b/loader
@@ -10,6 +10,7 @@ del _
 
 import os
 import sys
+import signal
 
 print(os.path.abspath(__file__))
 dirname, filename = os.path.split(__file__)
@@ -71,7 +72,26 @@ args, dbg_opts = parser.parse_known_args()
 #print('gdb:', args.gdb, 'lldb:', args.lldb,
 #  'core:', args.core, 'binary:', args.binary, 'opts:', args.opts)
 
-print(args)
+
+# leader the new process group
+os.setpgrp()
+
+def Abort():
+    print("Aborted, killall sub-processes.")
+    os.killpg(0, 9)
+
+# register signal
+def term_handler(signo, frame):
+    print('')
+    print("Received Signal(%d)" % signo)
+    Abort()
+
+signal.signal(signal.SIGINT, term_handler)
+signal.signal(signal.SIGTERM, term_handler)
+
+# node and node.typ path
+binary = None
+typfile = None
 
 def GetLoader(andb_dir):
     if args.gdb:
@@ -79,9 +99,6 @@ def GetLoader(andb_dir):
     elif args.lldb:
         return LldbLoader(andb_dir)
     return None
-
-binary = None
-typfile = None
 
 if args.binary:
     """ use specified binary
@@ -109,44 +126,38 @@ elif args.core:
 
 def IndexProcess(size):
     loader = GetLoader(andb_dir)
-    cmds = ['iso g p', 'mapreduce index %d'%size]
-    cmds = [x.split() for x in cmds]
     loader.SetExec(binary)
     loader.SetTyp(typfile)
     loader.SetCore(args.core)
     loader.BatchOn()
-    loader.AddCommands(cmds)
+    loader.AddCommandFile('%s/init/pre_mapreduce.cmd'%andb_dir)
+    loader.AddCommandLine('mapreduce index %d'%size)
     opts = loader.Opts()
-    os.system(" ".join(opts)) 
-    return opts
+    os.spawnvp(os.P_WAIT, opts[0], opts)
 
 def SnapProcess(index):
     print("my index is %d" % index)
     loader = GetLoader(andb_dir)
-    cmds = ['iso g p', 'mapreduce snapshot %d' % index]
-    cmds = [x.split() for x in cmds]
     loader.SetExec(binary)
     loader.SetTyp(typfile)
     loader.SetCore(args.core)
     loader.BatchOn()
-    loader.AddCommands(cmds)
+    loader.AddCommandFile('%s/init/pre_mapreduce.cmd'%andb_dir)
+    loader.AddCommandLine('mapreduce snapshot %d'%index)
     opts = loader.Opts()
-    os.system(" ".join(opts)) 
-    return opts
+    os.spawnvp(os.P_WAIT, opts[0], opts)
 
 def ReduceProcess(concurrency):
     loader = GetLoader(andb_dir)
-    cmds = ['iso g p', 'mapreduce reduce']
-    cmds = [x.split() for x in cmds]
     loader.SetExec(binary)
     loader.SetTyp(typfile)
     loader.SetCore(args.core)
     loader.BatchOn()
-    loader.AddCommands(cmds)
+    loader.AddCommandFile('%s/init/pre_mapreduce.cmd'%andb_dir)
+    loader.AddCommandLine('mapreduce reduce')
     opts = loader.Opts()
-    os.system(" ".join(opts)) 
-    return opts
-
+    os.spawnvp(os.P_WAIT, opts[0], opts)
+    
 def MapReduce():
     from multiprocessing import Process, Pool
     from time import time
@@ -157,16 +168,15 @@ def MapReduce():
     if args.jobs:
         concurrency = args.jobs
 
-    # map 
     p = Process(target=IndexProcess, args=(100,))
     p.start()
     p.join()
     t1 = time()
+    print("IndexProcesses done.")
 
-    # reduce
     reduce_process = Process(target=ReduceProcess, args=(concurrency,))
     reduce_process.start()
-    
+
     maps = [] 
     for f in os.listdir("snapshot.d"):
         if f.endswith(".map"):
@@ -175,13 +185,25 @@ def MapReduce():
     maps.sort()
     print(maps)
 
-    # parse
-    pool = Pool(processes=concurrency) 
-    [ pool.apply_async(SnapProcess, (i,)) for i in maps ]
+    pool = Pool(processes=concurrency)
+    results = [ pool.apply_async(SnapProcess, (i,)) for i in maps ]
     pool.close()
     pool.join()
     t2 = time()
+    print("SnapshotProcesses all done.")
 
+    failed = False
+    for i in maps:
+        if not os.path.exists("snapshot.d/snapshot_%d.rec" % i):
+            print("Job map_%d failed." % i)
+            failed = True
+
+    if failed:
+        print("ReduceProcess not satisfied.")
+        Abort()
+        assert 0
+
+    print("Wait ReduceProcess to complete ...")
     reduce_process.join()
     t3 = time()
 
@@ -210,8 +232,9 @@ else:
     if args.args and len(args.args) > 0:
         loader.AddArgs(args.args)
     if args.cmds and len(args.cmds) > 0:
+        print(args.cmds)
         loader.AddCommands(args.cmds)
 
     opts = loader.Opts() 
-    os.system(" ".join(opts))
+    os.spawnvp(os.P_WAIT, opts[0], opts)
 


### PR DESCRIPTION
Hi, All

for large corefile, the core.heapsnapshot exporting costs lots of time. 

the optimization introduced a new command, 

```
andb -c core.33 -m snapshot -j 8
```
to export core.heapsnapshot by using N processes concurrently.
it can reduce N times real time if you have a multi-cores CPU installed.

In my test, core.33 is about 1.8G bytes and has about 8m nodes and 32m edges,
normally costs 3+hrs for a single process exporting, 
now only costs 7min on my M1 MBP.
```
...
Polling done.
Resolve all edges ...
Done, resolved 4162, failed 0.
Total Entry(7782138), Edge(31256137)
heap snapshot written to 'core.heapsnapshot'
ReduceGenerate() takes 416.855 second(s).
real   435.652s
map    7.047s
parse  358.794s
reduce 69.811s
```

Get the object's memory address in Heapsnapshot,
another optimization is andb saved the memory address for each HeapObject in core.heapsnapshot file, let you inspect more in the debugger. each HeapObject has a unique Index normally can be identified from Devtools GUI, the number with '@' prefix after an object name.

`grep` it from core.heapsnapshot, memory address sits in the last.
```
$ grep ,6173663, core.heapsnapshot
,3,766,6173663,48,5,0,18796081870720

# inspect in andb
(lldb) p/x 18796081870720
(long) $0 = 0x000011184dc87780
(lldb) v8 o 0x000011184dc87780
[JSObject 0x11184dc87781]
- Properties:
 - _Logger: <JsObject 0x11184dc886a9>
 - _mod: <JsObject 0x11184dc886e1>
 - ErrorInfo: <JsArray 0x11184dc886f9>
- Elements: []
 - constructor: <JsFunction AAALoader 0x2e8c174333b9>
 - name: AAALoader
[Map 0x2342b62e0b9]
- InstanceSizeInWords: 6
- InobjectPropertiesStartOrConstructorFunctionIndex: 3
- UsedOrUnusedInstanceSizeInWords: 6
- VisitorId: 27
- InstanceType: JS_OBJECT_TYPE (1057)
- BitField: 0x0
...
```

some of the python files had been renamed, may need *.pyc cleaning up if odds.

Regards,
Zhaolei

