### PR TITLE
fix: added -t/--tag option

### DIFF
--- a/andb/cli/v8.py
+++ b/andb/cli/v8.py
@@ -64,13 +64,13 @@ class cli_isolate(CommandPrefix):
 class cli_isolate_guess_pages(Command):
     _cxpr = "isolate guess page"
 
-    def invoke (self, argv):
+    def invoke(self, argv):
         IsolateGuesser().GuessFromPages()
 
 class cli_isolate_guess_stack(Command):
     _cxpr = "isolate guess stack"
 
-    def invoke (self, argv):
+    def invoke(self, argv):
         IsolateGuesser().GuessFromStacks()
 
 

--- a/andb/shadow/visitor.py
+++ b/andb/shadow/visitor.py
@@ -22,32 +22,31 @@ class IsolateGuesser:
         v8.Isolate.SetCurrent(iso)
         # set convenience_variable
         dbg.ConvenienceVariables.Set('isolate', pyo_iso._I_value)
-        #iso.MakeChunkCache()
 
     def CheckIsolate(self, address):
         try:
             _iso = v8.Isolate(address)
             _heap_iso = _iso['heap_']['isolate_']
             if _iso == _heap_iso:
-                return _iso 
+                return _iso
         except:
             pass
         return None
 
     def CheckMemoryChunk(self, address):
-        m = v8.MemoryChunk(address) 
+        m = v8.MemoryChunk(address)
         _heap = m['heap_']
-        _iso = _heap['isolate_'] 
+        _iso = _heap['isolate_']
         _iso_heap = _iso['heap_'].AddressOf()
         if _heap == _iso_heap:
-            return _iso 
-        return None 
+            return _iso
+        return None
 
     def GuessFromStacks(self):
         """ walk all thread, guess from sp """
         for t in dbg.Target.GetThreads():
 
-            # get low addres from 'sp' 
+            # get low addres from 'sp'
             low = t.GetFrameTop().GetSP()
             
             # search for memory region of 'sp'
@@ -82,6 +81,7 @@ class IsolateGuesser:
                 try:
                     iso = self.CheckMemoryChunk(m.start_address)
                 except Exception as e:
+                    #print("0x%x %s" % (m.start_address, e))
                     iso = None
                 if iso is None:
                     continue

--- a/loader
+++ b/loader
@@ -66,7 +66,7 @@ parser.add_argument('-g', '--gdb', action='store_true', help='using gdb as debug
 parser.add_argument('-l', '--lldb', action='store_true', help='using lldb as debugger. (default)')
 parser.add_argument('-p', '--pid', nargs=1, type=int, help='the process id to attach to.')
 parser.add_argument('-b', '--batch', action='store_true', help='the process id to attach to.')
-parser.add_argument('-t', '--tag', nargs=1, type=int, help='specified version for debugging.')
+parser.add_argument('-t', '--tag', nargs=1, type=str, help='specified version for debugging.')
 parser.add_argument('-m', '--mode', nargs=1, choices=['snapshot', 'cache'], help='mapreduce mode (snapshot, cache).') 
 parser.add_argument('-j', '--jobs', action='store', type=int, help='jobs for mapreduce.')
 parser.add_argument('-x', '--command', dest='cmds', action='append', nargs="+", type=str, help='eval command can be multiple times.')
@@ -113,11 +113,15 @@ elif args.core:
     corepath = args.core
     corefileFmt = Corefile()
     corefileFmt.Load(corepath)
-    buildId = corefileFmt.GetBuildId()
-    print('build-id:', buildId)
 
     corefileAuxiliaryDownloader = CorefileAuxiliaryDownloader()
-    info = corefileAuxiliaryDownloader.Download(buildId)
+    
+    if args.tag and len(args.tag) > 0:
+        info = corefileAuxiliaryDownloader.FetchByTag(args.tag[0])
+    else:
+        buildId = corefileFmt.GetBuildId()
+        print('build-id:', buildId)
+        info = corefileAuxiliaryDownloader.FetchByBuildId(buildId)
 
     typfile = info['typ']
     os.environ['ANDB_TYP'] = typfile 


### PR DESCRIPTION
the patch supports -t/--tags option in andb cli,

```
andb -t alinode-v5.17.1 -c core.33
```

for corefile that dosen't have BuildID.