### PR TITLE
fix: send ctrl-c to debugger.

### DIFF
--- a/loader
+++ b/loader
@@ -251,6 +251,10 @@ if __name__ == '__main__':
         print(args.cmds)
         loader.AddCommands(args.cmds)
 
+    # ignore CTRL+C for python
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+    # spawn dbg
     opts = loader.Opts() 
     os.spawnvp(os.P_WAIT, opts[0], opts)
 


### PR DESCRIPTION
for os.spawn in python, ctrl-c KeyboardInterrupt will terminated the python and debugger processes.
the patch ignores the SIGINT in python pass through to the debugger.
