### PR TITLE
fix: restrict gdb V8 unwinder for only $rbp based frames.

### DIFF
--- a/loader
+++ b/loader
@@ -251,6 +251,10 @@ if __name__ == '__main__':
         print(args.cmds)
         loader.AddCommands(args.cmds)
 
+    # ignore CTRL+C for python
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+    # spawn dbg
     opts = loader.Opts() 
     os.spawnvp(os.P_WAIT, opts[0], opts)
 


### PR DESCRIPTION
the issue was found when backtrace a stack with rust addon function calls,
when rust addon compiled with optimization, the $rbp register is omitted from frame pointer,
thus cause 'v8 bt' can't unwinder the caller stack bellow.

the patch adds more restrictions, 
1)  a good $rbp should be not far from $rsp within 8MiB.
2) caller_sp should alwyas stay in stack.

