### PR TITLE
Feat sysroot

### DIFF
--- a/andb/loader/__init__.py
+++ b/andb/loader/__init__.py
@@ -2,4 +2,4 @@ from .elf import *
 from .core import *
 from .loader import *
 from .tsr import *
-
+from .sysroot import *

--- a/andb/loader/loader.py
+++ b/andb/loader/loader.py
@@ -144,7 +144,8 @@ class LldbLoader(Loader):
         return ['lldb', 
             '-x',  # no any .lldbinit
             '-o', "com sc im %s/init/lldbinit.py" % self._andb_dir,  # lldbinit python script
-            '-s', "%s/init/lldbinit.cmd" % self._andb_dir,             # lldbinit command
+            '-S', "%s/init/lldbpreinit.cmd" % self._andb_dir,        # lldb pre init commands
+            '-s', "%s/init/lldbinit.cmd" % self._andb_dir,           # lldb init command
            ]
 
     def Opts(self):

--- a/andb/loader/sysroot.py
+++ b/andb/loader/sysroot.py
@@ -170,7 +170,11 @@ class SysrootMaker(object):
 
         if not os.path.exists('sysroot'):
             os.makedirs('sysroot')
-       
+     
+        # let npm install in sysroot.
+        with open('sysroot/package.json', 'w') as f:
+            f.write('{}')
+
         print("node version:", self._node_version)
         self._files = self._tsr.GetFilesInfo()
 

--- a/andb/loader/sysroot.py
+++ b/andb/loader/sysroot.py
@@ -1,0 +1,171 @@
+
+from __future__ import print_function, division
+from .tsr import TechReport
+
+import os
+import re
+
+try:
+    from urllib.request import Request, urlopen 
+except ImportError:
+    from urllib2 import Request, urlopen
+import json
+
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        # possibly handle other errno cases here, otherwise finally:
+        else:
+            raise
+
+class Downloader(object):
+    pass
+
+
+class SysrootMaker(object):
+
+    # holds tsr 
+    _tsr = None
+
+    # holds node version, guessed from binary
+    _node_version = None
+
+    # sysroot dir name
+    _sysroot_dir = None
+
+    # binary path
+    _binary = None
+
+    def __init__(self, binPath, coreFmt, sysRoot="sysroot"):
+        self._binary = binPath
+        self._tsr = TechReport(coreFmt)
+        self._node_version = self.GuessNodeVersionFromBinary(binPath)
+        self._sysroot_dir = sysRoot
+        self._dwf_sysr_dir = os.path.expanduser("~/.andb-dwf/sysr")
+
+    @classmethod
+    def GuessNodeVersionFromBinary(cls, binary_path):
+        p = os.popen('strings "%s" | grep -o -E "node-v([0-9\.]+).tar.gz"' % binary_path) 
+        out = p.read()
+        p.close()
+        m = re.findall("node-v(\d+\.\d+\.\d+)\.*", out)
+        if len(m) > 0:
+            return m[0]
+        return None
+
+    def dwf_sysr_buildid(self, buildId):
+        return "%s/%s" % (self._dwf_sysr_dir, buildId) 
+
+    def BuildId(self, path_file):
+        p = os.popen('file -L "%s"' % path_file)
+        out = p.read()
+        p.close()
+        m = re.findall("BuildID\[sha1\]=([0-9a-f]+),", out)
+        if len(m) > 0:
+            return m[0]
+        return None
+
+    def FetchMeta(self, buildId):
+        url = 'https://alinode-debugger-info.oss-cn-zhangjiakou.aliyuncs.com/dwf/sysr/%s' % buildId
+        req = Request(url)
+        meta = urlopen(req).read().decode('utf8')
+        jm = json.loads(meta)
+        dm = self.dwf_sysr_buildid(buildId)
+        if not os.path.exists(dm):
+            os.makedirs(dm)
+        outf = "%s/%s" % (dm, jm['name'])
+        os.system("curl %s -o %s"  % (jm['url'], outf))
+        jm['local_file'] = outf
+        fm = "%s/metadata.json" % dm
+        with open(fm, 'w') as f: 
+            json.dump(jm, f)
+        return jm
+
+    def GetMeta(self, buildId):
+        dm = self.dwf_sysr_buildid(buildId)
+        fm = "%s/metadata.json" % dm
+        if os.path.exists(fm):
+            with open(fm) as f:
+                return json.load(f)
+        return self.FetchMeta(buildId)
+
+    def InstallDeb(self, meta):
+        rpm = meta['local_file']
+        os.system('cd sysroot && rpm2cpio "%s" | cpio -divm' % rpm) 
+
+    def InstallRpm(self, meta):
+        rpm = meta['local_file']
+        lib_d = "sysroot/%s.d" % meta['name']
+        if not os.path.exists(lib_d):
+            os.makedirs(lib_d)
+        os.system('cd "%s" && rpm2cpio "%s" | cpio -divm' % (lib_d, rpm)) 
+
+    def InstallLibc(self, f):
+        """Install libc package"""
+        meta = self.GetMeta(f['build_id']) 
+        if meta['type'] == 'rpm':
+            self.InstallRpm(meta)
+        elif meta['type'] == 'deb':
+            self.InstallDeb(meta)
+        else:
+            raise NotImplementedError
+
+    def InstallNpm(self, f):
+        """Install npm package"""
+        paths = f['name'].split("/")
+        if len(paths) < 1:
+            return 
+
+        dname = None
+        for i in range(len(paths)-1, 0, -1):
+            e = paths[i]
+            if e == 'node_modules':
+                dname = paths[i+1]
+                break
+        
+        if dname is None:
+            return
+       
+        vers = dname.split('@')
+        print(vers) 
+        
+        npm = os.environ.get('NPM')
+        if npm is None:
+            npm = 'npm'
+
+        if self._node_version is None:
+            return 
+
+        if len(vers) == 3:
+            os.system("cd sysroot && %s i --target=%s --target_arch=x64 --target_platform=linux %s@%s" % (npm, self._node_version, vers[2], vers[1]))
+        elif len(vers) == 5:
+            raise NotImplementedError
+
+    def InstallLinks(self):
+        dest = 'sysroot/lib64'
+        if not os.path.exists(dest):
+            os.makedirs(dest)
+        for d in os.listdir('sysroot'):
+            if d == 'lib64':
+                continue
+            if not os.path.isdir(d):
+                continue
+            print("install %s" % d)
+            os.system('cd "%s" && find "../%s" -name \"*.so\" -exec ln -sf {} \;' % (dest, d))
+            os.system('cd "%s" && find "../%s" -name \"*.so.*\" -exec ln -sf {} \;' % (dest, d))
+            os.system('cd "%s" && find "../%s" -name \"*.node\" -exec ln -sf {} \;' % (dest, d))
+
+    def Makeup(self):
+        self._files = self._tsr.GetFilesInfo()
+
+        for f in self._files:
+            if f['name'].find('libc-') > 0:
+                self.InstallLibc(f) 
+            elif f['name'].find('node_modules') > 0:
+                self.InstallNpm(f) 
+        
+        self.InstallLinks()
+

--- a/andb/loader/sysroot.py
+++ b/andb/loader/sysroot.py
@@ -159,6 +159,10 @@ class SysrootMaker(object):
             os.system('cd "%s" && find "../%s" -name \"*.node\" -exec ln -sf {} \;' % (dest, d))
 
     def Makeup(self):
+
+        if not os.path.exists('sysroot'):
+            os.makedirs('sysroot')
+        
         self._files = self._tsr.GetFilesInfo()
 
         for f in self._files:

--- a/andb/loader/sysroot.py
+++ b/andb/loader/sysroot.py
@@ -139,10 +139,12 @@ class SysrootMaker(object):
         if self._node_version is None:
             return 
 
+        # only support tnpm style, for version was in folder name.
         if len(vers) == 3:
             os.system("cd sysroot && %s i --target=%s --target_arch=x64 --target_platform=linux %s@%s" % (npm, self._node_version, vers[2], vers[1]))
         elif len(vers) == 5:
-            raise NotImplementedError
+            pkgver = "@%s/%s@%s" % (vers[4], paths[i+2], vers[2])
+            os.system("cd sysroot && %s i --target=%s --target_arch=x64 --target_platform=linux %s" % (npm, self._node_version, pkgver))
 
     def InstallLinks(self):
         dest = 'sysroot/lib64'
@@ -151,12 +153,12 @@ class SysrootMaker(object):
         for d in os.listdir('sysroot'):
             if d == 'lib64':
                 continue
-            if not os.path.isdir(d):
+            if not os.path.isdir("%s/%s" % ('sysroot', d)):
                 continue
             print("install %s" % d)
-            os.system('cd "%s" && find "../%s" -name \"*.so\" -exec ln -sf {} \;' % (dest, d))
-            os.system('cd "%s" && find "../%s" -name \"*.so.*\" -exec ln -sf {} \;' % (dest, d))
-            os.system('cd "%s" && find "../%s" -name \"*.node\" -exec ln -sf {} \;' % (dest, d))
+            os.system('cd "%s" && find "../%s" -name "*.so" -exec ln -sf {} \;' % (dest, d))
+            os.system('cd "%s" && find "../%s" -name "*.so.*" -exec ln -sf {} \;' % (dest, d))
+            os.system('cd "%s" && find "../%s" -name "*.node" -exec ln -sf {} \;' % (dest, d))
 
     def Makeup(self):
 

--- a/andb/loader/tsr.py
+++ b/andb/loader/tsr.py
@@ -160,6 +160,9 @@ class TechReport(object):
         out['md5'] = md5(self._core.filename)
         return out
 
+    def GetFilesInfo(self):
+        return self._core.GetFilesInfo()
+
     def GenerateCoreInfo(self):
         """Generate Corefile Info.
         """

--- a/init/gdbinit.cmd
+++ b/init/gdbinit.cmd
@@ -8,3 +8,6 @@ set auto-load python-scripts on
 set python print-stack full
 set height 0
 
+set sysroot sysroot
+set solib-search-path sysroot/lib64
+

--- a/init/lldbinit.cmd
+++ b/init/lldbinit.cmd
@@ -3,13 +3,6 @@
 #sc print(lldb.process)
 #sc print(lldb.debugger)
 
-#setting append target.exec-search-paths "sysroot/lib64"
-#target modules search-paths add "sysroot/lib64"
-#setting append target.debug-file-search-paths "."
-#setting set symbols.enable-external-lookup false
-#setting set plugin.symbol-file.dwarf.ignore-file-indexes true
-#setting set target.import-std-module false 
-
 # last load andb
 script import andb
 script andb.Load()

--- a/init/lldbinit.cmd
+++ b/init/lldbinit.cmd
@@ -3,9 +3,10 @@
 #sc print(lldb.process)
 #sc print(lldb.debugger)
 
-#setting append target.exec-search-paths "."
+#setting append target.exec-search-paths "sysroot/lib64"
+#target modules search-paths add "sysroot/lib64"
 #setting append target.debug-file-search-paths "."
-setting set symbols.enable-external-lookup false
+#setting set symbols.enable-external-lookup false
 #setting set plugin.symbol-file.dwarf.ignore-file-indexes true
 #setting set target.import-std-module false 
 

--- a/init/lldbpreinit.cmd
+++ b/init/lldbpreinit.cmd
@@ -1,0 +1,15 @@
+
+platform select --sysroot sysroot remote-linux
+
+#setting set target.exec-search-paths "sysroot/lib64"
+##setting set target.preload-symbols false 
+#
+#setting set target.clang-module-search-paths "sysroot/lib64"
+#setting set target.debug-file-search-paths "sysroot/lib/debug"
+#setting set target.auto-import-clang-modules false
+#
+#setting set symbols.enable-external-lookup false
+#setting set symbols.debug-info-symlink-paths "sysroot/lib/debug"
+#
+##setting set plugin.symbol-file.dwarf.ignore-file-indexes true
+##setting set target.import-std-module false 

--- a/init/lldbpreinit.cmd
+++ b/init/lldbpreinit.cmd
@@ -1,15 +1,4 @@
 
 platform select --sysroot sysroot remote-linux
+setting set target.exec-search-paths "sysroot/lib64"
 
-#setting set target.exec-search-paths "sysroot/lib64"
-##setting set target.preload-symbols false 
-#
-#setting set target.clang-module-search-paths "sysroot/lib64"
-#setting set target.debug-file-search-paths "sysroot/lib/debug"
-#setting set target.auto-import-clang-modules false
-#
-#setting set symbols.enable-external-lookup false
-#setting set symbols.debug-info-symlink-paths "sysroot/lib/debug"
-#
-##setting set plugin.symbol-file.dwarf.ignore-file-indexes true
-##setting set target.import-std-module false 

--- a/loader
+++ b/loader
@@ -75,6 +75,7 @@ parser.add_argument('-c', '--core', nargs="?", type=str, help='path to corefile.
 parser.add_argument('--args', nargs=argparse.REMAINDER, help='debugger options')
 parser.add_argument('binary', nargs="?", type=str, help='node or shinki binaray')
 parser.add_argument('-z', '--tsr', action='store_true', help='Generate Technical Support Report.')
+parser.add_argument('--sysroot', action='store_true', help='Makeup sysroot for corefile.')
 
 args, dbg_opts = parser.parse_known_args()
 
@@ -241,6 +242,14 @@ if __name__ == '__main__':
         elif args.binary:
             txt = TechReportText(args.binary)
             txt.ShowAll()
+        exit(0)
+
+    # Makeup sysroot
+    if args.sysroot:
+        from andb.loader import SysrootMaker
+        print('makeup sysroot')
+        srm = SysrootMaker(binary, corefileFmt, sysRoot="sysroot")
+        srm.Makeup()
         exit(0)
 
     # map reduce mode


### PR DESCRIPTION
the host running andb may not have the libraries which the corefile is used, thus andb adds the sysroot support.

andb will search libraries in `sysroot/lib64` folder in workdir instead of host installed, but use host libraries if the folder is absent.

all libraries should keep flat in `sysroot/lib64`, subfolder is ignored.

a new cli for making up the sysroot from the information of corefile,
```
andb -c core.<pid> --sysroot
```
but only a few OS was supported right now.

andb --sysroot installs npm package as well if the node_module sub-folders have the package version information.
for speedup npm install, a Environ Var `NPM` is used to change the default `npm` binary in any npm cli.
```
NPM=tnpm andb -c core.<pid> --sysroot
```

