### PR TITLE
fix: NoneType object get position

### DIFF
--- a/andb/dbg/intf_dbg.py
+++ b/andb/dbg/intf_dbg.py
@@ -704,9 +704,11 @@ class Frame(object):
             args.append(str(i))
 
         position = ""
-        filename, fileline = self.GetPosition()
-        if filename and fileline:
-            position = "at %s:%d" % (filename, fileline)
+        position_info = self.GetPosition()
+        if position_info:
+            filename, fileline = position_info
+            if filename and fileline:
+                position = "at %s:%d" % (filename, fileline)
 
         if not full:
             return "0x%016x %s(%s) %s" % (


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/19389266-eead-4a68-8d6c-c9527e064a28)

Check backtrace to trigger this bug, so it's fixed, PTAL